### PR TITLE
dont pass --repo as args to klipper

### DIFF
--- a/pkg/helm/controller.go
+++ b/pkg/helm/controller.go
@@ -303,9 +303,6 @@ func args(chart *helmv1.HelmChart) []string {
 	if spec.TargetNamespace != "" {
 		args = append(args, "--namespace", spec.TargetNamespace)
 	}
-	if spec.Repo != "" {
-		args = append(args, "--repo", spec.Repo)
-	}
 	if spec.Version != "" {
 		args = append(args, "--version", spec.Version)
 	}


### PR DESCRIPTION
The helm-controller passes in an env var for REPO that is used to setup the helm repo.

https://github.com/rancher/klipper-helm/blob/master/entry#L16

It also passes in `--repo` as an arg to the klipper container. The bash script in klipper then runs all args which doesn't work.

I've not been able to get `--repo` working even with a stable chart in the official repo via command line. It always says chart not found in repo when specifying `--repo` so I'm not sure if this still works.