### PR TITLE
Add ability to override job image

### DIFF
--- a/manifests/crd.yaml
+++ b/manifests/crd.yaml
@@ -7,6 +7,10 @@ spec:
   group: helm.cattle.io
   version: v1
   additionalPrinterColumns:
+  - name: Job
+    type: string
+    description: Job associated with updates to this chart
+    JSONPath: .status.jobName
   - name: Chart
     type: string
     description: Helm Chart name

--- a/pkg/apis/helm.cattle.io/v1/types.go
+++ b/pkg/apis/helm.cattle.io/v1/types.go
@@ -26,6 +26,7 @@ type HelmChartSpec struct {
 	HelmVersion     string                        `json:"helmVersion,omitempty"`
 	Bootstrap       bool                          `json:"bootstrap,omitempty"`
 	ChartContent    string                        `json:"chartContent,omitempty"`
+	JobImage        string                        `json:"jobImage,omitempty"`
 }
 
 type HelmChartStatus struct {

--- a/pkg/helm/controller_test.go
+++ b/pkg/helm/controller_test.go
@@ -16,7 +16,7 @@ func TestInstallJob(t *testing.T) {
 	chart := NewChart()
 	job, _, _ := job(chart)
 	assert.Equal("helm-install-traefik", job.Name)
-	assert.Equal(image, job.Spec.Template.Spec.Containers[0].Image)
+	assert.Equal(DefaultJobImage, job.Spec.Template.Spec.Containers[0].Image)
 	assert.Equal("helm-traefik", job.Spec.Template.Spec.ServiceAccountName)
 }
 


### PR DESCRIPTION
Also make the default image name exported so we can reference it
externally.

Related to https://github.com/rancher/rke2/issues/271

Signed-off-by: Brad Davidson <brad.davidson@rancher.com>